### PR TITLE
Refactor GetIt - inject all dependencies in constructor

### DIFF
--- a/lib/source_remote/di/inject_dependencies.dart
+++ b/lib/source_remote/di/inject_dependencies.dart
@@ -16,11 +16,11 @@ void injectDependencies(GetIt getIt) {
   );
 
   getIt.registerFactory<FeedRepository>(
-    () => FeedRepositoryImpl(getIt.get()),
+    () => FeedRepositoryImpl(getIt.get(), getIt.get()),
   );
 
   getIt.registerFactory<ProfileRepository>(
-    () => ProfileRepositoryImpl(getIt.get()),
+    () => ProfileRepositoryImpl(getIt.get(), getIt.get()),
   );
 
   getIt.registerFactory<NewTweetRepository>(

--- a/lib/source_remote/impl/feed_repository_impl.dart
+++ b/lib/source_remote/impl/feed_repository_impl.dart
@@ -1,21 +1,19 @@
 import 'package:flutter_dasher/common/model/tweet.dart';
 import 'package:flutter_dasher/domain/data/user_data_holder.dart';
 import 'package:flutter_dasher/domain/repository/feed_repository.dart';
-import 'package:get_it/get_it.dart';
 import 'package:intl/intl.dart';
 import 'package:twitter_api_v2/twitter_api_v2.dart';
 
 class FeedRepositoryImpl implements FeedRepository {
-  FeedRepositoryImpl(this.twitterApi);
+  FeedRepositoryImpl(this.twitterApi, this.userDataHolder);
 
   final TwitterApi twitterApi;
+  final UserDataHolder userDataHolder;
 
   @override
   Future<List<Tweet>> fetchFeedTimeline() async {
-    var user = GetIt.instance.get<UserDataHolder>().user;
-
     final response = await twitterApi.tweetsService.lookupHomeTimeline(
-      userId: user!.id,
+      userId: userDataHolder.user!.id,
       tweetFields: [
         TweetField.publicMetrics,
         TweetField.createdAt,

--- a/lib/source_remote/impl/profile_repository_impl.dart
+++ b/lib/source_remote/impl/profile_repository_impl.dart
@@ -1,21 +1,19 @@
 import 'package:flutter_dasher/common/model/tweet.dart';
 import 'package:flutter_dasher/domain/data/user_data_holder.dart';
 import 'package:flutter_dasher/domain/repository/profile_repository.dart';
-import 'package:get_it/get_it.dart';
 import 'package:intl/intl.dart';
 import 'package:twitter_api_v2/twitter_api_v2.dart';
 
 class ProfileRepositoryImpl implements ProfileRepository {
-  ProfileRepositoryImpl(this.twitterApi);
+  ProfileRepositoryImpl(this.twitterApi, this.userDataHolder);
 
   final TwitterApi twitterApi;
+  final UserDataHolder userDataHolder;
 
   @override
   Future<List<Tweet>> fetchProfileTweets() async {
-    var user = GetIt.instance.get<UserDataHolder>().user;
-
     final response = await twitterApi.tweetsService.lookupTweets(
-      userId: user!.id,
+      userId: userDataHolder.user!.id,
       tweetFields: [
         TweetField.publicMetrics,
         TweetField.createdAt,


### PR DESCRIPTION
Following @zenled advice:
For example in the `FeedRepositoryImpl.fetchFeedTimeline` I would not use `get_it` to get the `UserDataHolder`. I would inject the `UserDataHolder` the same way as `TwitterApi` is injected.
If the dependencies are injected in constructors, it makes it easier to write tests.